### PR TITLE
Add model download helper script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__/
 # --- OS 関連 ---
 .DS_Store
 Thumbs.db
+frontend/models/

--- a/README.md
+++ b/README.md
@@ -14,8 +14,12 @@
    pip install -r backend/requirements.txt
    ```
 3. **モデルファイルを配置**
-   - `frontend/models` に face-api.js のモデルファイル（`ssd_mobilenetv1_model-weights_manifest.json` など）を配置します。
-   - モデルは [face-api.js](https://github.com/justadudewhohacks/face-api.js/) から入手してください。
+   - `frontend/models` に face-api.js のモデルファイルを配置します。
+   - 以下のスクリプトで自動ダウンロードできます。
+     ```bash
+     ./scripts/download_models.sh
+     ```
+   - 手動で入手する場合は [face-api.js](https://github.com/justadudewhohacks/face-api.js/) の `weights` ディレクトリから取得してください。
 4. **サーバー起動**
    ```bash
    cd backend

--- a/scripts/download_models.sh
+++ b/scripts/download_models.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODEL_DIR="frontend/models"
+BASE_URL="https://raw.githubusercontent.com/justadudewhohacks/face-api.js/master/weights"
+
+mkdir -p "$MODEL_DIR"
+
+files=(
+  "age_gender_model-shard1"
+  "age_gender_model-weights_manifest.json"
+  "face_expression_model-shard1"
+  "face_expression_model-weights_manifest.json"
+  "face_landmark_68_model-shard1"
+  "face_landmark_68_model-weights_manifest.json"
+  "face_landmark_68_tiny_model-shard1"
+  "face_landmark_68_tiny_model-weights_manifest.json"
+  "face_recognition_model-shard1"
+  "face_recognition_model-shard2"
+  "face_recognition_model-weights_manifest.json"
+  "mtcnn_model-shard1"
+  "mtcnn_model-weights_manifest.json"
+  "ssd_mobilenetv1_model-shard1"
+  "ssd_mobilenetv1_model-shard2"
+  "ssd_mobilenetv1_model-weights_manifest.json"
+  "tiny_face_detector_model-shard1"
+  "tiny_face_detector_model-weights_manifest.json"
+)
+
+for file in "${files[@]}"; do
+  echo "Downloading $file"
+  curl -L "$BASE_URL/$file" -o "$MODEL_DIR/$file"
+done
+
+printf '\nAll models downloaded to %s\n' "$MODEL_DIR"


### PR DESCRIPTION
## Summary
- add script `download_models.sh` to fetch face-api.js models
- update README with instructions to run the script
- ignore `frontend/models` directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68491ba3a81c8324913ea2f29eef6cfc