### PR TITLE
Improve marker UI interactions

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -24,5 +24,5 @@ body {
 }
 
 .emoji-marker.hidden {
-    opacity: 0;
+    opacity: 0.3;
 }


### PR DESCRIPTION
## Summary
- avoid showing the original image before masking finishes
- place new markers in the centre
- keep marker positions consistent when downloading
- prevent markers from hiding when being dragged
- allow resizing markers with the mouse wheel
- make hidden markers semi-transparent

## Testing
- `python -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6849678be1008324b22265d2458207a5