### PR TITLE
Fix marker opacity and pinned button

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -61,7 +61,7 @@ document.getElementById('download').addEventListener('click', () => {
     const scaleY = uploadedImage.naturalHeight / uploadedImage.clientHeight;
 
     document.querySelectorAll('.emoji-marker').forEach(span => {
-        if (span.classList.contains('hidden')) return;
+        if (span.classList.contains('dimmed')) return;
         const left = parseFloat(span.style.left);
         const top = parseFloat(span.style.top);
         const width = parseFloat(span.style.width);
@@ -137,7 +137,7 @@ function createMarker(x, y, width, height) {
             span._wasDragged = false;
             return;
         }
-        span.classList.toggle('hidden');
+        span.classList.toggle('dimmed');
     });
 
     makeDraggableResizable(span);

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -23,7 +23,9 @@ body {
     font-size: 1rem;
 }
 
-.emoji-marker.hidden {
+
+/* Marker becomes semi-transparent when dimmed */
+.emoji-marker.dimmed {
     opacity: 0.3;
 }
 
@@ -34,4 +36,21 @@ body {
 #loading {
     margin-top: 1rem;
     font-weight: bold;
+}
+
+/* Fixed position buttons */
+#addMarker, #download {
+    position: fixed;
+    right: 20px;
+    width: 140px;
+    height: 40px;
+    font-size: 14px;
+}
+
+#addMarker {
+    bottom: 70px;
+}
+
+#download {
+    bottom: 20px;
 }


### PR DESCRIPTION
## Summary
- make markers semi-transparent instead of disappearing
- pin Add Marker and Download buttons to a fixed screen location

## Testing
- `python3 -m py_compile backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68496df16ac4832488a0468035f721b2