### PR TITLE
Improve front‑end design

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,12 +9,16 @@
 </head>
 
 <body>
-    <h1>Mask Face App</h1>
-    <input type="file" id="imageUpload" accept="image/jpeg,image/png" />
-    <div id="loading" class="hidden">Processing...</div>
-    <div class="image-container"></div>
-    <button id="addMarker">Add Marker</button>
-    <button id="download">Download Masked Image</button>
+    <div class="app-card">
+        <h1>Mask Face App</h1>
+        <input type="file" id="imageUpload" accept="image/jpeg,image/png" />
+        <div id="loading" class="hidden">Processing...</div>
+        <div class="image-container"></div>
+        <div class="button-row">
+            <button id="addMarker">Add Marker</button>
+            <button id="download">Download Masked Image</button>
+        </div>
+    </div>
 
     <script src="libs/face-api.min.js"></script>
     <script src="main.js"></script>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,17 +1,40 @@
+:root {
+    --accent-color: #6c63ff;
+}
+
 body {
-    font-family: sans-serif;
-    padding: 1rem;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
+        Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    background: #f5f7fa;
+    margin: 0;
+    padding: 2rem;
     text-align: center;
 }
+
+.app-card {
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+    padding: 2rem;
+    margin: 0 auto;
+    max-width: 800px;
+    display: grid;
+    gap: 1.5rem;
+}
+
 
 .image-container {
     position: relative;
     display: inline-block;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
 }
 
 .image-container img {
     max-height: 480px;
     object-fit: contain;
+    display: block;
 }
 
 .emoji-marker {
@@ -22,6 +45,12 @@ body {
     align-items: center;
     justify-content: center;
     font-size: 1rem;
+    transition: transform 0.2s ease, filter 0.2s ease;
+}
+
+.emoji-marker:hover {
+    transform: scale(1.2);
+    filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.2));
 }
 
 
@@ -39,28 +68,32 @@ body {
     font-weight: bold;
 }
 
-/* Fixed position buttons */
+.button-row {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+}
+
 #addMarker,
 #download {
-    position: fixed;
-    right: 20px;
-    width: 140px;
-    height: 40px;
+    padding: 0.5rem 1rem;
+    border: none;
+    border-radius: 4px;
+    background: var(--accent-color);
+    color: #fff;
+    cursor: pointer;
     font-size: 14px;
+    transition: background 0.2s ease, transform 0.2s ease;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+
+#addMarker:hover,
+#download:hover {
+    background: #5848d6;
+    transform: translateY(-2px);
 }
 
 #imageUpload {
-    position: fixed;
-    left: 20px;
-    bottom: 20px;
-    width: auto;
-    z-index: 1000;
-}
-
-#addMarker {
-    bottom: 70px;
-}
-
-#download {
-    bottom: 20px;
+    width: 200px;
+    margin: 0 auto;
 }


### PR DESCRIPTION
## Summary
- redesign frontend layout using a card style container
- add accent color and hover effects
- update marker styles with transitions

## Testing
- `python -m py_compile backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_684985f58328832485b7ed2f1db35608