### PR TITLE
Allow emoji selection for new markers

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,6 +16,16 @@
         <div id="loading" class="hidden">Processing...</div>
         <div class="image-container"></div>
         <div class="button-row">
+            <select id="emojiSelector" class="emoji-selector">
+                <option value="😊">😊</option>
+                <option value="😠">😠</option>
+                <option value="🤢">🤢</option>
+                <option value="😨">😨</option>
+                <option value="😄">😄</option>
+                <option value="😐">😐</option>
+                <option value="😢">😢</option>
+                <option value="😮">😮</option>
+            </select>
             <button id="addMarker">Add Marker</button>
             <button id="download">Download Masked Image</button>
         </div>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -71,7 +71,9 @@ addMarkerBtn.addEventListener('click', () => {
     const size = 80;
     const x = (uploadedImage.clientWidth - size) / 2;
     const y = (uploadedImage.clientHeight - size) / 2;
-    const span = createMarker(x, y, size, size);
+    const selector = document.getElementById('emojiSelector');
+    const emoji = selector ? selector.value : '😊';
+    const span = createMarker(x, y, size, size, emoji);
     container.appendChild(span);
 });
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -75,6 +75,12 @@ body {
     justify-content: center;
 }
 
+.emoji-selector {
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    font-size: 14px;
+}
+
 #addMarker,
 #download {
     padding: 0.5rem 1rem;


### PR DESCRIPTION
## Summary
- add a dropdown to choose an emoji when adding markers
- style the emoji dropdown
- use selected emoji when creating a new marker

## Testing
- `python -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_684a1dafdc008324aa27b1003fb50aa8